### PR TITLE
use python to readlink instead of coreutils

### DIFF
--- a/Formula/sceptrefun.rb
+++ b/Formula/sceptrefun.rb
@@ -9,7 +9,6 @@ class Sceptrefun < Formula
     end
   
     depends_on "mplayer"
-    depends_on "coreutils"
   
     def install
         bin.install "sceptrefun"

--- a/sceptrefun
+++ b/sceptrefun
@@ -1,6 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-BASEDIR=$(cd "$(dirname "$(dirname "$(greadlink -f $0)")")" && pwd)
+realpath() {
+  python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"
+}
+
+BASEDIR="$(dirname "$(dirname "$(realpath "$0")")")"
 
 SCEPTRE_SUCCESS="$BASEDIR/assets/war3_jobdone.mp3"
 SCEPTRE_UPGRADE_STACK="$BASEDIR/assets/war3_jobdone.mp3"


### PR DESCRIPTION
There is no need to install dependency, when it's possible to resolve link with existing tool.